### PR TITLE
Fix theme layout issues

### DIFF
--- a/_featured_categories/blog.md
+++ b/_featured_categories/blog.md
@@ -1,7 +1,6 @@
 ---
 # Featured tags need to have either the `list` or `grid` layout (PRO only).
-layout: list
-
+layout: page
 # The title of the tag's page.
 title: 블로그
 
@@ -19,3 +18,12 @@ description: >
 # DON'T USE THIS SETTING IN YOUR CATEGORIES!
 sitemap: false
 ---
+
+{% assign posts = site.categories.blog %}
+<ul>
+{% for post in posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+  </li>
+{% endfor %}
+</ul>

--- a/_featured_tags/ai.md
+++ b/_featured_tags/ai.md
@@ -1,6 +1,6 @@
 ---
 # Featured tags need to have either the `list` or `grid` layout (PRO only).
-layout: tag
+layout: page
 
 # The title of the tag's page.
 title: AI
@@ -15,3 +15,12 @@ description: >
 # (Optional) You can disable grouping posts by date.
 # no_groups: true
 ---
+
+{% assign posts = site.tags.AI %}
+<ul>
+{% for post in posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+  </li>
+{% endfor %}
+</ul>

--- a/_featured_tags/design.md
+++ b/_featured_tags/design.md
@@ -1,6 +1,6 @@
 ---
 # Featured tags need to have either the `list` or `grid` layout (PRO only).
-layout: tag
+layout: page
 
 # The title of the tag's page.
 title: 디자인
@@ -15,3 +15,12 @@ description: >
 # (Optional) You can disable grouping posts by date.
 # no_groups: true
 ---
+
+{% assign posts = site.tags.디자인 %}
+<ul>
+{% for post in posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+  </li>
+{% endfor %}
+</ul>

--- a/_pages/categories.md
+++ b/_pages/categories.md
@@ -1,7 +1,18 @@
 ---
-layout: categories
+layout: page
 title: 카테고리
 permalink: /categories/
 description: >
   카테고리별로 정리된 블로그 포스트
 ---
+
+{% assign categories = site.categories | sort %}
+<ul>
+{% for category in categories %}
+  <li>
+    <a href="{{ site.baseurl }}/category/{{ category[0] | slugify }}/">
+      {{ category[0] }} ({{ category[1].size }})
+    </a>
+  </li>
+{% endfor %}
+</ul>

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -1,7 +1,18 @@
 ---
-layout: tags
+layout: page
 title: 태그
 permalink: /tags/
 description: >
   태그별로 정리된 블로그 포스트
 ---
+
+{% assign tags = site.tags | sort %}
+<ul>
+{% for tag in tags %}
+  <li>
+    <a href="{{ site.baseurl }}/tag/{{ tag[0] | slugify }}/">
+      {{ tag[0] }} ({{ tag[1].size }})
+    </a>
+  </li>
+{% endfor %}
+</ul>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-layout: blog
+layout: home
 title: 기술 블로그
 description: >
   최신 기술 트렌드와 디자인 툴에 대한 정보를 제공하는 블로그입니다.


### PR DESCRIPTION
## Summary
- use existing `home` layout on index
- replace missing taxonomy layouts with simple pages for categories and tags
- ensure featured tag/category pages use `page` layout with post lists

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684117e92b0883328e23a15bdb6f36af